### PR TITLE
Add invariant handler functions for Franchiser contract

### DIFF
--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -16,7 +16,7 @@ contract FranchiseFactoryInvariantTest is Test {
         token = new VotingTokenConcrete();
         factory = new FranchiserFactory(IVotingToken(address(token)));
         handler = new FranchiserFactoryHandler(factory);
-        bytes4[] memory selectors = new bytes4[](8);
+        bytes4[] memory selectors = new bytes4[](9);
         selectors[0] = FranchiserFactoryHandler.factory_fundMany.selector;
         selectors[1] = FranchiserFactoryHandler.factory_recallMany.selector;
         selectors[2] = FranchiserFactoryHandler.factory_recall.selector;
@@ -25,6 +25,7 @@ contract FranchiseFactoryInvariantTest is Test {
         selectors[5] = FranchiserFactoryHandler.factory_permitAndFundMany.selector;
         selectors[6] = FranchiserFactoryHandler.franchiser_subDelegate.selector;
         selectors[7] = FranchiserFactoryHandler.franchiser_subDelegateMany.selector;
+        selectors[8] = FranchiserFactoryHandler.franchiser_recall.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -45,7 +45,7 @@ contract FranchiseFactoryInvariantTest is Test {
     }
 
     // Used to see distribution of non-reverting calls
-    function invariant_callSummary() public view {
+    function invariant_callSummary() public {
         handler.callSummary();
     }
 }

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -17,14 +17,14 @@ contract FranchiseFactoryInvariantTest is Test {
         factory = new FranchiserFactory(IVotingToken(address(token)));
         handler = new FranchiserFactoryHandler(factory);
         bytes4[] memory selectors = new bytes4[](8);
-        selectors[0] = FranchiserFactoryHandler.handler_fundMany.selector;
-        selectors[1] = FranchiserFactoryHandler.handler_recallMany.selector;
-        selectors[2] = FranchiserFactoryHandler.handler_recall.selector;
-        selectors[3] = FranchiserFactoryHandler.handler_fund.selector;
-        selectors[4] = FranchiserFactoryHandler.handler_permitAndFund.selector;
-        selectors[5] = FranchiserFactoryHandler.handler_permitAndFundMany.selector;
-        selectors[6] = FranchiserFactoryHandler.handler_subDelegate.selector;
-        selectors[7] = FranchiserFactoryHandler.handler_subDelegateMany.selector;
+        selectors[0] = FranchiserFactoryHandler.factory_fundMany.selector;
+        selectors[1] = FranchiserFactoryHandler.factory_recallMany.selector;
+        selectors[2] = FranchiserFactoryHandler.factory_recall.selector;
+        selectors[3] = FranchiserFactoryHandler.factory_fund.selector;
+        selectors[4] = FranchiserFactoryHandler.factory_permitAndFund.selector;
+        selectors[5] = FranchiserFactoryHandler.factory_permitAndFundMany.selector;
+        selectors[6] = FranchiserFactoryHandler.franchiser_subDelegate.selector;
+        selectors[7] = FranchiserFactoryHandler.franchiser_subDelegateMany.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -38,7 +38,7 @@ contract FranchiseFactoryInvariantTest is Test {
         handler.callSummary();
         assertEq(
             token.totalSupply(),
-            token.balanceOf(handler.targetAddressForRecalledFunds()) + handler.sumFundedFranchisersBalances()
+            handler.sumDelegatorsBalances() + handler.sumFundedFranchisersBalances()
         );
     }
 

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -16,13 +16,14 @@ contract FranchiseFactoryInvariantTest is Test {
         token = new VotingTokenConcrete();
         factory = new FranchiserFactory(IVotingToken(address(token)));
         handler = new FranchiserFactoryHandler(factory);
-        bytes4[] memory selectors = new bytes4[](6);
+        bytes4[] memory selectors = new bytes4[](7);
         selectors[0] = FranchiserFactoryHandler.handler_fundMany.selector;
         selectors[1] = FranchiserFactoryHandler.handler_recallMany.selector;
         selectors[2] = FranchiserFactoryHandler.handler_recall.selector;
         selectors[3] = FranchiserFactoryHandler.handler_fund.selector;
         selectors[4] = FranchiserFactoryHandler.handler_permitAndFund.selector;
         selectors[5] = FranchiserFactoryHandler.handler_permitAndFundMany.selector;
+        selectors[6] = FranchiserFactoryHandler.handler_subDelegate.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }
@@ -31,7 +32,7 @@ contract FranchiseFactoryInvariantTest is Test {
         assertGt(address(handler.franchiser()).code.length, 0);
     }
 
-    function invariant_Franchisers_and_recalled_balance_sum_matches_total_supply() external view {
+    function invariant_Franchisers_and_recalled_balance_sum_matches_total_supply() external {
         handler.callSummary();
         assertEq(
             token.totalSupply(),

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -16,7 +16,7 @@ contract FranchiseFactoryInvariantTest is Test {
         token = new VotingTokenConcrete();
         factory = new FranchiserFactory(IVotingToken(address(token)));
         handler = new FranchiserFactoryHandler(factory);
-        bytes4[] memory selectors = new bytes4[](9);
+        bytes4[] memory selectors = new bytes4[](11);
         selectors[0] = FranchiserFactoryHandler.factory_fundMany.selector;
         selectors[1] = FranchiserFactoryHandler.factory_recallMany.selector;
         selectors[2] = FranchiserFactoryHandler.factory_recall.selector;
@@ -26,6 +26,8 @@ contract FranchiseFactoryInvariantTest is Test {
         selectors[6] = FranchiserFactoryHandler.franchiser_subDelegate.selector;
         selectors[7] = FranchiserFactoryHandler.franchiser_subDelegateMany.selector;
         selectors[8] = FranchiserFactoryHandler.franchiser_recall.selector;
+        selectors[9] = FranchiserFactoryHandler.franchiser_unSubDelegate.selector;
+        selectors[10] = FranchiserFactoryHandler.franchiser_unSubDelegateMany.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -17,17 +17,17 @@ contract FranchiseFactoryInvariantTest is Test {
         factory = new FranchiserFactory(IVotingToken(address(token)));
         handler = new FranchiserFactoryHandler(factory);
         bytes4[] memory selectors = new bytes4[](11);
-        selectors[0] = FranchiserFactoryHandler.factory_fundMany.selector;
-        selectors[1] = FranchiserFactoryHandler.factory_recallMany.selector;
+        selectors[0] = FranchiserFactoryHandler.factory_fund.selector;
+        selectors[1] = FranchiserFactoryHandler.factory_fundMany.selector;
         selectors[2] = FranchiserFactoryHandler.factory_recall.selector;
-        selectors[3] = FranchiserFactoryHandler.factory_fund.selector;
+        selectors[3] = FranchiserFactoryHandler.factory_recallMany.selector;
         selectors[4] = FranchiserFactoryHandler.factory_permitAndFund.selector;
         selectors[5] = FranchiserFactoryHandler.factory_permitAndFundMany.selector;
         selectors[6] = FranchiserFactoryHandler.franchiser_subDelegate.selector;
         selectors[7] = FranchiserFactoryHandler.franchiser_subDelegateMany.selector;
-        selectors[8] = FranchiserFactoryHandler.franchiser_recall.selector;
-        selectors[9] = FranchiserFactoryHandler.franchiser_unSubDelegate.selector;
-        selectors[10] = FranchiserFactoryHandler.franchiser_unSubDelegateMany.selector;
+        selectors[8] = FranchiserFactoryHandler.franchiser_unSubDelegate.selector;
+        selectors[9] = FranchiserFactoryHandler.franchiser_unSubDelegateMany.selector;
+        selectors[10] = FranchiserFactoryHandler.franchiser_recall.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -44,6 +44,12 @@ contract FranchiseFactoryInvariantTest is Test {
         );
     }
 
+    function invariant_updated_balances_and_voting_power_correctly() external {
+        handler.callSummary();
+        assertTrue(handler.balances_updated_correctly());
+        assertTrue(handler.voting_powers_updated_correctly());
+    }
+
     // Used to see distribution of non-reverting calls
     function invariant_callSummary() public {
         handler.callSummary();

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -16,7 +16,7 @@ contract FranchiseFactoryInvariantTest is Test {
         token = new VotingTokenConcrete();
         factory = new FranchiserFactory(IVotingToken(address(token)));
         handler = new FranchiserFactoryHandler(factory);
-        bytes4[] memory selectors = new bytes4[](7);
+        bytes4[] memory selectors = new bytes4[](8);
         selectors[0] = FranchiserFactoryHandler.handler_fundMany.selector;
         selectors[1] = FranchiserFactoryHandler.handler_recallMany.selector;
         selectors[2] = FranchiserFactoryHandler.handler_recall.selector;
@@ -24,6 +24,7 @@ contract FranchiseFactoryInvariantTest is Test {
         selectors[4] = FranchiserFactoryHandler.handler_permitAndFund.selector;
         selectors[5] = FranchiserFactoryHandler.handler_permitAndFundMany.selector;
         selectors[6] = FranchiserFactoryHandler.handler_subDelegate.selector;
+        selectors[7] = FranchiserFactoryHandler.handler_subDelegateMany.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }

--- a/test/handlers/FranchiserFactoryHandler.sol
+++ b/test/handlers/FranchiserFactoryHandler.sol
@@ -337,29 +337,6 @@ contract FranchiserFactoryHandler is Test {
     }
 
     // This function will do recalls only from Franchisers that have sub-delegatees
-    function franchiser_recall() external countCall("franchiser_recall") {
-        if (fundedFranchisers.length() == 0) {
-            return;
-        }
-        // find a funded franchiser that has sub-delegatees
-        uint256 _subDelegateCount = 0;
-        uint256 _fundedFranchiserIndex = 0;
-        while ( (_fundedFranchiserIndex < fundedFranchisers.length()) && (_subDelegateCount == 0)) {
-            _subDelegateCount = Franchiser(fundedFranchisers.at(_fundedFranchiserIndex)).subDelegatees().length;
-            if (_subDelegateCount == 0) _fundedFranchiserIndex++;
-        }
-        if (_subDelegateCount == 0) {
-            return;
-        }
-        Franchiser _selectedFranchiser = Franchiser(fundedFranchisers.at(_fundedFranchiserIndex));
-        address _delegator = _selectedFranchiser.delegator();
-
-        // recall the delegated funds
-        vm.prank(_selectedFranchiser.owner());
-        _selectedFranchiser.recall(_delegator);
-    }
-
-    // This function will do recalls only from Franchisers that have sub-delegatees
     function franchiser_unSubDelegate() external countCall("franchiser_unSubDelegate") {
         if (fundedFranchisers.length() == 0) {
             return;
@@ -404,6 +381,29 @@ contract FranchiserFactoryHandler is Test {
         delete lastSubDelegatedFranchisersArray;
     }
 
+    // This function will do recalls only from Franchisers that have sub-delegatees
+    function franchiser_recall() external countCall("franchiser_recall") {
+        if (fundedFranchisers.length() == 0) {
+            return;
+        }
+        // find a funded franchiser that has sub-delegatees
+        uint256 _subDelegateCount = 0;
+        uint256 _fundedFranchiserIndex = 0;
+        while ( (_fundedFranchiserIndex < fundedFranchisers.length()) && (_subDelegateCount == 0)) {
+            _subDelegateCount = Franchiser(fundedFranchisers.at(_fundedFranchiserIndex)).subDelegatees().length;
+            if (_subDelegateCount == 0) _fundedFranchiserIndex++;
+        }
+        if (_subDelegateCount == 0) {
+            return;
+        }
+        Franchiser _selectedFranchiser = Franchiser(fundedFranchisers.at(_fundedFranchiserIndex));
+        address _delegator = _selectedFranchiser.delegator();
+
+        // recall the delegated funds
+        vm.prank(_selectedFranchiser.owner());
+        _selectedFranchiser.recall(_delegator);
+    }
+
     function callSummary() external view {
         console2.log("\nCall summary:");
         console2.log("-------------------");
@@ -415,9 +415,9 @@ contract FranchiserFactoryHandler is Test {
         console2.log("factory_permitAndFundMany", calls["factory_permitAndFundMany"].calls);
         console2.log("franchiser_subDelegate", calls["franchiser_subDelegate"].calls);
         console2.log("franchiser_subDelegateMany", calls["franchiser_subDelegateMany"].calls);
-        console2.log("franchiser_recall", calls["franchiser_recall"].calls);
         console2.log("franchiser_unSubDelegate", calls["franchiser_unSubDelegate"].calls);
         console2.log("franchiser_unSubDelegateMany", calls["franchiser_unSubDelegateMany"].calls);
+        console2.log("franchiser_recall", calls["franchiser_recall"].calls);
         console2.log("-------------------\n");
     }
 }

--- a/test/handlers/FranchiserFactoryHandler.sol
+++ b/test/handlers/FranchiserFactoryHandler.sol
@@ -80,7 +80,7 @@ contract FranchiserFactoryHandler is Test {
     }
 
     // Recursive function to get the selected subDelegatee of a given funded franchiser if possible
-    function _getSelectedSubDelegateeIfPossible(Franchiser _fundedFranchiser, uint256 _subDelegateIndex) internal returns (Franchiser _selectedFranchiser) {
+    function _getDeepestSubDelegateeInTree(Franchiser _fundedFranchiser, uint256 _subDelegateIndex) internal returns (Franchiser _selectedFranchiser) {
         _selectedFranchiser = _fundedFranchiser;
         address[] memory _subDelegatees = _selectedFranchiser.subDelegatees();
         if (_subDelegatees.length > 0) {
@@ -90,7 +90,7 @@ contract FranchiserFactoryHandler is Test {
             vm.startPrank(address(_selectedFranchiser));
             _selectedFranchiser = _selectedFranchiser.getFranchiser(_selectedFranchiser.subDelegatees()[_subDelegateIndex]);
             vm.stopPrank();
-            _selectedFranchiser = _getSelectedSubDelegateeIfPossible(_selectedFranchiser, _subDelegateIndex);
+            _selectedFranchiser = _getDeepestSubDelegateeInTree(_selectedFranchiser, _subDelegateIndex);
         }
     }
 
@@ -141,7 +141,7 @@ contract FranchiserFactoryHandler is Test {
         }
         _fundedFranchiserIndex = bound(_fundedFranchiserIndex, 0, fundedFranchisers.length() - 1);
         Franchiser _selectedFranchiser = Franchiser(fundedFranchisers.at(_fundedFranchiserIndex));
-        _selectedFranchiser = _getSelectedSubDelegateeIfPossible(_selectedFranchiser, _subDelegateeIndex);
+        _selectedFranchiser = _getDeepestSubDelegateeInTree(_selectedFranchiser, _subDelegateeIndex);
         address _delegatee = _selectedFranchiser.delegatee();
         address _delegator = _selectedFranchiser.delegator();
         uint256 _amount = _getTotalAmountDelegatedByFranchiser(address(_selectedFranchiser));
@@ -227,7 +227,7 @@ contract FranchiserFactoryHandler is Test {
         }
         _fundedFranchiserIndex = bound(_fundedFranchiserIndex, 0, fundedFranchisers.length() - 1);
         Franchiser _selectedFranchiser = Franchiser(fundedFranchisers.at(_fundedFranchiserIndex));
-        _selectedFranchiser = _getSelectedSubDelegateeIfPossible(_selectedFranchiser, _subDelegateIndex);
+        _selectedFranchiser = _getDeepestSubDelegateeInTree(_selectedFranchiser, _subDelegateIndex);
         uint256 _amount = votingToken.balanceOf(address(_selectedFranchiser));
         if (_amount == 0) {
             return;

--- a/test/handlers/FranchiserFactoryHandler.sol
+++ b/test/handlers/FranchiserFactoryHandler.sol
@@ -212,7 +212,7 @@ contract FranchiserFactoryHandler is Test {
     }
 
     // Invariant Handler functions for Franchiser contract
-    function handler_subDelegate(address _subDelegatee, uint256 _fundedFranchiserIndex, uint256 _subDelegateIndex) external countCall("handler_subDelegate") {
+    function handler_subDelegate(address _subDelegatee, uint256 _fundedFranchiserIndex, uint256 _subDelegateIndex, uint256 _subDelegateAmountFraction) external countCall("handler_subDelegate") {
         if (fundedFranchisers.length() == 0) {
             return;
         }
@@ -226,8 +226,10 @@ contract FranchiserFactoryHandler is Test {
         address _delegatee = _selectedFranchiser.delegatee();
         vm.assume(_validActorAddress(_subDelegatee));
         vm.assume(_delegatee != _subDelegatee);
+        _subDelegateAmountFraction = bound(_subDelegateAmountFraction, 1, _amount);
+        uint256 _subDelegateAmount = _amount / _subDelegateAmountFraction;
         vm.prank(_delegatee);
-        _selectedFranchiser.subDelegate(_subDelegatee, _amount);
+        _selectedFranchiser.subDelegate(_subDelegatee, _subDelegateAmount);
     }
 
     function callSummary() external view {

--- a/test/handlers/FranchiserFactoryHandler.sol
+++ b/test/handlers/FranchiserFactoryHandler.sol
@@ -57,7 +57,8 @@ contract FranchiserFactoryHandler is Test {
         valid = (_address != address(0))
             && (
                 _address != address(votingToken) && (_address != address(factory))
-                    && (!fundedFranchisers.contains(_address))
+                    && (!fundedFranchisers.contains(_address)
+                    && (!subDelegatedFranchisers.contains(_address)))
             );
     }
 

--- a/test/helpers/EnumerableSet.sol
+++ b/test/helpers/EnumerableSet.sol
@@ -4,6 +4,7 @@
 // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/structs/EnumerableSet.sol
 
 // Added reduce function to EnumerableSet.AddressSet to reduce the set to a single value
+// Added add function to EnumerableSet.AddressSet to add an array of values to the set
 
 // OpenZeppelin Contracts (last updated v4.7.0) (utils/structs/EnumerableSet.sol)
 
@@ -237,6 +238,16 @@ library EnumerableSet {
      */
     function add(AddressSet storage set, address value) internal returns (bool) {
         return _add(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Add a an array of values to a set. O(n).
+     *
+     */
+    function add(AddressSet storage set, address[] memory value) internal {
+        for (uint256 i; i < value.length; ++i) {
+            _add(set._inner, bytes32(uint256(uint160(value[i]))));
+        }
     }
 
     /**

--- a/test/helpers/EnumerableSet.sol
+++ b/test/helpers/EnumerableSet.sol
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: MIT
+
+// EnumerableSet comes from OpenZeppelin Contracts:
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/structs/EnumerableSet.sol
+
+// Added reduce function to EnumerableSet.AddressSet to reduce the set to a single value
+
+// OpenZeppelin Contracts (last updated v4.7.0) (utils/structs/EnumerableSet.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Library for managing
+ * https://en.wikipedia.org/wiki/Set_(abstract_data_type)[sets] of primitive
+ * types.
+ *
+ * Sets have the following properties:
+ *
+ * - Elements are added, removed, and checked for existence in constant time
+ * (O(1)).
+ * - Elements are enumerated in O(n). No guarantees are made on the ordering.
+ *
+ * ```
+ * contract Example {
+ *     // Add the library methods
+ *     using EnumerableSet for EnumerableSet.AddressSet;
+ *
+ *     // Declare a set state variable
+ *     EnumerableSet.AddressSet private mySet;
+ * }
+ * ```
+ *
+ * As of v3.3.0, sets of type `bytes32` (`Bytes32Set`), `address` (`AddressSet`)
+ * and `uint256` (`UintSet`) are supported.
+ *
+ * [WARNING]
+ * ====
+ *  Trying to delete such a structure from storage will likely result in data corruption, rendering the structure unusable.
+ *  See https://github.com/ethereum/solidity/pull/11843[ethereum/solidity#11843] for more info.
+ *
+ *  In order to clean an EnumerableSet, you can either remove all elements one by one or create a fresh instance using an array of EnumerableSet.
+ * ====
+ */
+library EnumerableSet {
+    // To implement this library for multiple types with as little code
+    // repetition as possible, we write it in terms of a generic Set type with
+    // bytes32 values.
+    // The Set implementation uses private functions, and user-facing
+    // implementations (such as AddressSet) are just wrappers around the
+    // underlying Set.
+    // This means that we can only create new EnumerableSets for types that fit
+    // in bytes32.
+
+    struct Set {
+        // Storage of set values
+        bytes32[] _values;
+        // Position of the value in the `values` array, plus 1 because index 0
+        // means a value is not in the set.
+        mapping(bytes32 => uint256) _indexes;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function _add(Set storage set, bytes32 value) private returns (bool) {
+        if (!_contains(set, value)) {
+            set._values.push(value);
+            // The value is stored at length-1, but we add 1 to all indexes
+            // and use 0 as a sentinel value
+            set._indexes[value] = set._values.length;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function _remove(Set storage set, bytes32 value) private returns (bool) {
+        // We read and store the value's index to prevent multiple reads from the same storage slot
+        uint256 valueIndex = set._indexes[value];
+
+        if (valueIndex != 0) {
+            // Equivalent to contains(set, value)
+            // To delete an element from the _values array in O(1), we swap the element to delete with the last one in
+            // the array, and then remove the last element (sometimes called as 'swap and pop').
+            // This modifies the order of the array, as noted in {at}.
+
+            uint256 toDeleteIndex = valueIndex - 1;
+            uint256 lastIndex = set._values.length - 1;
+
+            if (lastIndex != toDeleteIndex) {
+                bytes32 lastValue = set._values[lastIndex];
+
+                // Move the last value to the index where the value to delete is
+                set._values[toDeleteIndex] = lastValue;
+                // Update the index for the moved value
+                set._indexes[lastValue] = valueIndex; // Replace lastValue's index to valueIndex
+            }
+
+            // Delete the slot where the moved value was stored
+            set._values.pop();
+
+            // Delete the index for the deleted slot
+            delete set._indexes[value];
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function _contains(Set storage set, bytes32 value) private view returns (bool) {
+        return set._indexes[value] != 0;
+    }
+
+    /**
+     * @dev Returns the number of values on the set. O(1).
+     */
+    function _length(Set storage set) private view returns (uint256) {
+        return set._values.length;
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function _at(Set storage set, uint256 index) private view returns (bytes32) {
+        return set._values[index];
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function _values(Set storage set) private view returns (bytes32[] memory) {
+        return set._values;
+    }
+
+    // Bytes32Set
+
+    struct Bytes32Set {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(Bytes32Set storage set, bytes32 value) internal returns (bool) {
+        return _add(set._inner, value);
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(Bytes32Set storage set, bytes32 value) internal returns (bool) {
+        return _remove(set._inner, value);
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(Bytes32Set storage set, bytes32 value) internal view returns (bool) {
+        return _contains(set._inner, value);
+    }
+
+    /**
+     * @dev Returns the number of values in the set. O(1).
+     */
+    function length(Bytes32Set storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(Bytes32Set storage set, uint256 index) internal view returns (bytes32) {
+        return _at(set._inner, index);
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function values(Bytes32Set storage set) internal view returns (bytes32[] memory) {
+        return _values(set._inner);
+    }
+
+    // AddressSet
+
+    struct AddressSet {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(AddressSet storage set, address value) internal returns (bool) {
+        return _add(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(AddressSet storage set, address value) internal returns (bool) {
+        return _remove(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(AddressSet storage set, address value) internal view returns (bool) {
+        return _contains(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Returns the number of values in the set. O(1).
+     */
+    function length(AddressSet storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(AddressSet storage set, uint256 index) internal view returns (address) {
+        return address(uint160(uint256(_at(set._inner, index))));
+    }
+
+    /**
+     * @dev Returns the sum of accumlating all of the results of the given function run on each element of the AddressSet.
+     *
+     */
+    function reduce(
+        AddressSet storage set,
+        uint256 acc,
+        function(address) returns (uint256) func
+    ) internal returns (uint256) {
+        for (uint256 i; i < length(set); ++i) {
+            acc += func(address(uint160(uint256(_at(set._inner, i)))));
+        }
+        return acc;
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function values(AddressSet storage set) internal view returns (address[] memory) {
+        bytes32[] memory store = _values(set._inner);
+        address[] memory result;
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := store
+        }
+
+        return result;
+    }
+
+    // UintSet
+
+    struct UintSet {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(UintSet storage set, uint256 value) internal returns (bool) {
+        return _add(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(UintSet storage set, uint256 value) internal returns (bool) {
+        return _remove(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(UintSet storage set, uint256 value) internal view returns (bool) {
+        return _contains(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Returns the number of values on the set. O(1).
+     */
+    function length(UintSet storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(UintSet storage set, uint256 index) internal view returns (uint256) {
+        return uint256(_at(set._inner, index));
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function values(UintSet storage set) internal view returns (uint256[] memory) {
+        bytes32[] memory store = _values(set._inner);
+        uint256[] memory result;
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := store
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
Adding invariant handler functions for the Franchiser contract and more for the FranchiserFactory contract, including tracking of balances and voting power for Franchiser delegation trees.

The following system properties will be tracked by the code added by this PR:

#### FranchiserFactory

#### recall

- [ ] votingToken.balanceOf(msg.sender) should increase by the sum of the votingToken balances of the delegatee subtree.

#### fund

- [ ] votingToken.balanceOf(msg.sender) should decrease by _amount
- [ ] votingToken.balanceOf(franchiser) should increase by _amount
- [ ] votingToken.getVotes(delegatee) should increase by _amount

(Above also checked for `fundMany`, `recallMany`, `permitAndFund`, `permitAndFundMany`

#### Franchiser
#### subDelegate

- [ ] votingToken.balanceOf(franchiser) should increase by _amount
- [ ] votingToken.balanceOf(address(this)) should decrease by _amount
- [ ] votingToken.getVotes(subDelegatee) should increase by _amount
- [ ] votingToken.getVotes(delegatee) should decrease by _amount

#### unSubDelegate

- [ ] votingToken.balanceOf(address(this)) should increase by the sum of the votingToken balances of the subDelegatee subtree.

#### recall

- [ ] votingToken.balanceOf(to) should increase by the sum of the votingToken balances of all sub-delegatee subtrees in the _subDelegatees EnumerableSet.

#### Other
- [ ] Checking getVotes for all associated addresses after functions calls to fund, subDelegate, unSubDelegate, subDelegatemany, unSubDelegateMany, etc.
