### PR TITLE
Refactor naming of expiredRecall and expiredRecallMany

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,18 +9,18 @@ optimizer_runs = 1000000
 bytecode_hash = "none"
 
 [profile.ci]
-  fuzz = { runs = 5000 }
-  invariant = { runs = 1000 }
+fuzz = { runs = 500 }
+invariant = { runs = 50 }
 
 [invariant]
-  call_override = false
-  depth = 100
-  dictionary_weight = 80
-  fail_on_revert = false
-  include_push_bytes = true
-  include_storage = true
-  optimizer = false
-  runs = 25
+call_override = false
+runs = 25
+depth = 100
+dictionary_weight = 80
+fail_on_revert = false
+include_push_bytes = true
+include_storage = true
+optimizer = false
 
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
+++ b/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
@@ -22,6 +22,11 @@ interface IFranchiserFactory is
     /// @return The Franchiser implementation contract.
     function franchiserImplementation() external view returns (Franchiser);
 
+    /// @notice Returns the `expiration` timestamp for a given `franchiser`.
+    /// @param franchiser The target `franchiser`.
+    /// @return The timestamp when the franchiser's voting power expires.
+    function expirations(Franchiser franchiser) external view returns (uint256);
+
     /// @notice Looks up the Franchiser associated with the `owner` and `delegatee`.
     /// @dev Returns the address of the Franchiser even it it does not yet exist,
     ///      thanks to CREATE2.
@@ -39,8 +44,9 @@ interface IFranchiserFactory is
     ///      If a Franchiser does not yet exist, one is created.
     /// @param delegatee The target `delegatee`.
     /// @param amount The amount of `votingToken` to allocate.
+    /// @param expiration The timestamp when the delegatee's voting power expires.
     /// @return franchiser The Franchiser contract.
-    function fund(address delegatee, uint256 amount)
+    function fund(address delegatee, uint256 amount, uint256 expiration)
         external
         returns (Franchiser franchiser);
 
@@ -48,8 +54,9 @@ interface IFranchiserFactory is
     /// @dev Requires the sender of the call to have approved this contract for sum of `amounts`.
     /// @param delegatees The target `delegatees`.
     /// @param amounts The amounts of `votingToken` to allocate.
+    /// @param expiration The timestamp when the delegatee's voting power expires.
     /// @return franchisers The Franchiser contracts.
-    function fundMany(address[] calldata delegatees, uint256[] calldata amounts)
+    function fundMany(address[] calldata delegatees, uint256[] calldata amounts, uint256 expiration)
         external
         returns (Franchiser[] memory franchisers);
 
@@ -65,12 +72,25 @@ interface IFranchiserFactory is
     function recallMany(address[] calldata delegatees, address[] calldata tos)
         external;
 
+    /// @notice Recalls voting tokens from an expired delegatee back to the owner.
+    /// @dev Can be called by anyone, but only after the delegatee's expiration time has passed.
+    /// @dev Will revert with `DelegateeNotExpired` if called before expiration time.
+    /// @param owner The target `owner`.
+    /// @param delegatee The address of the delegatee whose tokens should be recalled.
+    function expiredRecall(address owner, address delegatee) external;
+
+    /// @notice Calls expiredRecall many times.
+    /// @param owners The target `owners`.
+    /// @param delegatees The target `delegatees`.
+    function expiredRecallMany(address[] calldata owners, address[] calldata delegatees) external;
+
     /// @notice Funds the Franchiser contract associated with the `delegatee`
     ///         using a signature.
     /// @dev The signature must have been produced by the sender of the call.
     ///      If a Franchiser does not yet exist, one is created.
     /// @param delegatee The target `delegatee`.
     /// @param amount The amount of `votingToken` to allocate.
+    /// @param expiration The timestamp when the delegatee's voting power expires.
     /// @param deadline A timestamp which the current timestamp must be less than or equal to.
     /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`.
     /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`.
@@ -79,6 +99,7 @@ interface IFranchiserFactory is
     function permitAndFund(
         address delegatee,
         uint256 amount,
+        uint256 expiration,
         uint256 deadline,
         uint8 v,
         bytes32 r,
@@ -89,6 +110,7 @@ interface IFranchiserFactory is
     /// @dev The permit must be for the sum of `amounts`.
     /// @param delegatees The target `delegatees`.
     /// @param amounts The amounts of `votingToken` to allocate.
+    /// @param expiration The timestamp when the delegatee's voting power expires.
     /// @param deadline A timestamp which the current timestamp must be less than or equal to.
     /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`.
     /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`.
@@ -97,6 +119,7 @@ interface IFranchiserFactory is
     function permitAndFundMany(
         address[] calldata delegatees,
         uint256[] calldata amounts,
+        uint256 expiration,
         uint256 deadline,
         uint8 v,
         bytes32 r,

--- a/src/interfaces/FranchiserFactory/IFranchiserFactoryErrors.sol
+++ b/src/interfaces/FranchiserFactory/IFranchiserFactoryErrors.sol
@@ -7,4 +7,10 @@ interface IFranchiserFactoryErrors {
     /// @param length0 The length of the first array argument.
     /// @param length1 The length of the second array argument.
     error ArrayLengthMismatch(uint256 length0, uint256 length1);
+
+    /// @notice Thrown when attempting to set an expiration timestamp that is in the past
+    error InvalidExpiration();
+
+    /// @notice Thrown when attempting to recall tokens from a delegatee before their delegation has expired
+    error DelegateeNotExpired();
 }

--- a/test/Franchiser.t.sol
+++ b/test/Franchiser.t.sol
@@ -405,6 +405,7 @@ contract FranchiserTest is Test, IFranchiserErrors, IFranchiserEvents {
         vm.assume(_validActorAddress(_delegatee));
         vm.assume(_validActorAddress(_attacker));
         vm.assume(_validActorAddress(_delegator));
+        vm.assume(_attacker != _delegator);
         _amount = bound(_amount, 4, 100_000_000e18);
         votingToken.mint(_delegator, _amount);
 

--- a/test/FranchiserLens.t.sol
+++ b/test/FranchiserLens.t.sol
@@ -15,6 +15,8 @@ contract FranchiserLensTest is Test {
     FranchiserFactory private franchiserFactory;
     FranchiserLens private franchiserLens;
 
+    uint safeFutureExpiration = block.timestamp + 1 weeks;
+
     function setUp() public {
         votingToken = new VotingTokenConcrete();
         franchiserFactory = new FranchiserFactory(
@@ -38,7 +40,8 @@ contract FranchiserLensTest is Test {
             1,
             vm,
             votingToken,
-            franchiserFactory
+            franchiserFactory,
+            safeFutureExpiration
         );
 
         IFranchiserLens.Delegation memory rootDelegation = franchiserLens
@@ -66,7 +69,8 @@ contract FranchiserLensTest is Test {
             2,
             vm,
             votingToken,
-            franchiserFactory
+            franchiserFactory,
+            safeFutureExpiration
         );
 
         IFranchiserLens.Delegation memory rootDelegation = franchiserLens
@@ -106,7 +110,8 @@ contract FranchiserLensTest is Test {
             5,
             vm,
             votingToken,
-            franchiserFactory
+            franchiserFactory,
+            safeFutureExpiration
         );
 
         IFranchiserLens.Delegation memory rootDelegation = franchiserLens
@@ -171,7 +176,8 @@ contract FranchiserLensTest is Test {
         Franchiser[][5] memory franchisers = Utils.nestMaximum(
             vm,
             votingToken,
-            franchiserFactory
+            franchiserFactory,
+            safeFutureExpiration
         );
 
         IFranchiserLens.DelegationWithVotes[][]

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -43,8 +43,10 @@ contract IntegrationTest is Test {
         IGovernorBravo(0x408ED6354d4973f66138C91495F2f2FCbd8724C3);
 
     FranchiserFactory private franchiserFactory;
+    uint safeFutureExpiration;
 
     function setUp() public {
+        safeFutureExpiration = block.timestamp + 1 weeks;
         vm.startPrank(address(0));
         franchiserFactory = new FranchiserFactory(UNI);
         // fund the timelock with 1 ETH to send txs
@@ -58,7 +60,7 @@ contract IntegrationTest is Test {
 
         vm.startPrank(address(TIMELOCK));
         UNI.approve(address(franchiserFactory), quorumVotes);
-        franchiserFactory.fund(Utils.alice, quorumVotes);
+        franchiserFactory.fund(Utils.alice, quorumVotes, safeFutureExpiration);
         vm.stopPrank();
 
         // encode a call to send 1 wei of UNI to alice

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -21,7 +21,8 @@ library Utils {
         uint256 levels,
         Vm vm,
         VotingTokenConcrete votingToken,
-        FranchiserFactory franchiserFactory
+        FranchiserFactory franchiserFactory,
+        uint256 expiration
     ) internal returns (Franchiser[5] memory franchisers) {
         assert(levels != 0);
         assert(levels <= 5);
@@ -35,7 +36,7 @@ library Utils {
         votingToken.mint(alice, 1);
         vm.startPrank(alice);
         votingToken.approve(address(franchiserFactory), 1);
-        franchisers[0] = franchiserFactory.fund(delegatees[0], 1);
+        franchisers[0] = franchiserFactory.fund(delegatees[0], 1, expiration);
         vm.stopPrank();
 
         unchecked {
@@ -60,7 +61,8 @@ library Utils {
     function nestMaximum(
         Vm vm,
         VotingTokenConcrete votingToken,
-        FranchiserFactory franchiserFactory
+        FranchiserFactory franchiserFactory,
+        uint256 expiration
     ) internal returns (Franchiser[][5] memory franchisers) {
         assert(franchiserFactory.INITIAL_MAXIMUM_SUBDELEGATEES() == 8);
         assert(
@@ -78,7 +80,7 @@ library Utils {
         votingToken.mint(address(1), 64);
         vm.startPrank(address(1));
         votingToken.approve(address(franchiserFactory), 64);
-        franchisers[0][0] = franchiserFactory.fund(nextDelegatee, 64);
+        franchisers[0][0] = franchiserFactory.fund(nextDelegatee, 64, expiration);
         vm.stopPrank();
 
         nextDelegatee = incrementNextDelegatee(nextDelegatee);

--- a/test/handlers/FranchiserFactoryHandler.sol
+++ b/test/handlers/FranchiserFactoryHandler.sol
@@ -13,6 +13,8 @@ contract FranchiserFactoryHandler is Test {
     using EnumerableSet for EnumerableSet.AddressSet;
     using Address for address;
 
+    uint safeFutureExpiration = block.timestamp + 1 weeks;
+
     FranchiserFactory public factory;
     Franchiser public franchiser;
     Franchiser public subDelegatedFranchiser;
@@ -207,7 +209,7 @@ contract FranchiserFactoryHandler is Test {
         votingToken.mint(_delegator, _amount);
         vm.startPrank(_delegator);
         votingToken.approve(address(factory), _amount);
-        franchiser = factory.fund(_delegatee, _amount);
+        franchiser = factory.fund(_delegatee, _amount, safeFutureExpiration);
         vm.stopPrank();
 
         // add the created franchiser to the fundedFranchisers AddressSet for tracking totals invariants
@@ -244,7 +246,7 @@ contract FranchiserFactoryHandler is Test {
 
         // clear the storage of the lastFundedFranchisersArray and create a new one with call to fundMany
         delete lastFundedFranchisersArray;
-        lastFundedFranchisersArray = factory.fundMany(_delegatees, _amountsForFundMany);
+        lastFundedFranchisersArray = factory.fundMany(_delegatees, _amountsForFundMany, safeFutureExpiration);
         vm.stopPrank();
 
         // add the delegator to the delegators AddressSets for tracking totals invariants
@@ -323,7 +325,7 @@ contract FranchiserFactoryHandler is Test {
         votingToken.mint(_delegator, _amount);
 
         vm.prank(_delegator);
-        franchiser = factory.permitAndFund(_delegatee, _amount, _deadline, _v, _r, _s);
+        franchiser = factory.permitAndFund(_delegatee, _amount, _deadline, safeFutureExpiration, _v, _r, _s);
 
         // add the created franchiser to the fundedFranchisers AddressSet for tracking totals invariants
         _increaseFundedFranchiserAccountBalance(franchiser, _amount);
@@ -358,7 +360,7 @@ contract FranchiserFactoryHandler is Test {
 
         // clear the storage of the lastFundedFranchisersArray and create a new one with call to fundMany
         delete lastFundedFranchisersArray;
-        lastFundedFranchisersArray = factory.permitAndFundMany(_delegatees, _amountsForFundMany, _deadline, _v, _r, _s);
+        lastFundedFranchisersArray = factory.permitAndFundMany(_delegatees, _amountsForFundMany, _deadline, safeFutureExpiration, _v, _r, _s);
         vm.stopPrank();
 
         // add the delegator to the delegators AddressSet for tracking totals invariants


### PR DESCRIPTION
Rename all mentions of `expiredRecall` -> `recallExpired`, `expiredRecallMany` -> `recallManyExpired`